### PR TITLE
Changing location of markdownlint container image

### DIFF
--- a/.github/workflows/VerifyDocument.yml
+++ b/.github/workflows/VerifyDocument.yml
@@ -12,4 +12,4 @@ jobs:
 
       - name: Verify Markdown structure
         run: |
-          docker run --rm -v $(pwd):/workdir -t ghcr.io/andmos/markdownlint "*.md"
+            docker run --rm -v $(pwd):/workdir -t ghcr.io/andmos/markdownlint:master "*.md"

--- a/.github/workflows/VerifyDocument.yml
+++ b/.github/workflows/VerifyDocument.yml
@@ -12,4 +12,4 @@ jobs:
 
       - name: Verify Markdown structure
         run: |
-          docker run --rm -v $(pwd):/usr/src/app/files -t andmos/markdownlint *.md
+          docker run --rm -v $(pwd):/workdir -t ghcr.io/andmos/markdownlint "*.md"


### PR DESCRIPTION
Using the ghcr-build of the container image directly from the fork of markdownlint.